### PR TITLE
Hdp314 discovery tool bug fix

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="67a4d1c7-09fc-4ad2-bbe1-3c329ee80bdb" name="Default Changelist" comment="Add verify=False for HTTPS request">
-      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/mr_workload_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/mr_workload_extractor.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/spark_workload_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/spark_workload_extractor.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/tez_workload_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/tez_workload_extractor.py" afterDir="false" />
+    <list default="true" id="cb0a075c-ecf9-4eeb-acf1-4d3d456bfaf6" name="Changes" comment=":construction: typo fixed">
+      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/ranger_policy_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/ranger_policy_extractor.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="67a4d1c7-09fc-4ad2-bbe1-3c329ee80bdb" name="Default Changelist" comment="Hive Code Scanner" />
+    <list default="true" id="67a4d1c7-09fc-4ad2-bbe1-3c329ee80bdb" name="Default Changelist" comment="Hive Code Scanner">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/ambari_api_extarctor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/ambari_api_extarctor.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdfs_fs_image_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdfs_fs_image_extractor.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdp_metrics_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdp_metrics_extractor.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/mr_workload_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/mr_workload_extractor.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/spark_workload_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/spark_workload_extractor.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/tez_workload_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/tez_workload_extractor.py" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -9,6 +17,13 @@
   </component>
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="HighlightingSettingsPerFile">
+    <setting file="file://$PROJECT_DIR$/upgrade-toolkit/CDH-Discovery-Tool/requirements.txt" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-reports-builder/mac_report_builder.py" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/upgrade-toolkit/CDH-Discovery-Tool/mac-discovery-reports-builder/mac_report_builder.py" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/discovery_bundle_builder.sh" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/conf/log-config.yaml" root0="FORCE_HIGHLIGHTING" />
   </component>
   <component name="ProjectId" id="2Lf3vSgqiUkWi7ELlt1ynoqgn90" />
   <component name="ProjectViewState">
@@ -73,7 +88,6 @@
         </entry>
       </map>
     </option>
-    <option name="oldMeFiltersMigrated" value="true" />
   </component>
   <component name="VcsManagerConfiguration">
     <MESSAGE value="Hive Code Scanner" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="67a4d1c7-09fc-4ad2-bbe1-3c329ee80bdb" name="Default Changelist" comment="Hive Code Scanner">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/ambari_api_extarctor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/ambari_api_extarctor.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdfs_fs_image_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdfs_fs_image_extractor.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdp_metrics_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdp_metrics_extractor.py" afterDir="false" />
+    <list default="true" id="67a4d1c7-09fc-4ad2-bbe1-3c329ee80bdb" name="Default Changelist" comment="Add verify=False for HTTPS request">
       <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/mr_workload_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/mr_workload_extractor.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/spark_workload_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/spark_workload_extractor.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/tez_workload_extractor.py" beforeDir="false" afterPath="$PROJECT_DIR$/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/tez_workload_extractor.py" afterDir="false" />
@@ -63,7 +59,14 @@
       <option name="project" value="LOCAL" />
       <updated>1676250304555</updated>
     </task>
-    <option name="localTasksCounter" value="3" />
+    <task id="LOCAL-00003" summary="Add verify=False for HTTPS request">
+      <created>1679650119505</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1679650119505</updated>
+    </task>
+    <option name="localTasksCounter" value="4" />
     <servers />
   </component>
   <component name="Vcs.Log.Tabs.Properties">
@@ -91,6 +94,7 @@
   </component>
   <component name="VcsManagerConfiguration">
     <MESSAGE value="Hive Code Scanner" />
-    <option name="LAST_COMMIT_MESSAGE" value="Hive Code Scanner" />
+    <MESSAGE value="Add verify=False for HTTPS request" />
+    <option name="LAST_COMMIT_MESSAGE" value="Add verify=False for HTTPS request" />
   </component>
 </project>

--- a/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/ambari_api_extarctor.py
+++ b/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/ambari_api_extarctor.py
@@ -188,7 +188,7 @@ class AmbariApiExtractor:
 
     def get_cluster_name(self):
         try:
-            r = requests.get(self.ambari_http_protocol+"://"+self.ambari_server_host+":"+self.ambari_server_port+"/api/v1/clusters",auth = HTTPBasicAuth(self.ambari_user, self.ambari_pass))
+            r = requests.get(self.ambari_http_protocol+"://"+self.ambari_server_host+":"+self.ambari_server_port+"/api/v1/clusters",auth = HTTPBasicAuth(self.ambari_user, self.ambari_pass),verify=False)
 
         except requests.exceptions.RequestException as e:
             log.debug(

--- a/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdfs_fs_image_extractor.py
+++ b/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdfs_fs_image_extractor.py
@@ -126,7 +126,7 @@ class HdfsFsImageExtractor:
         try:
             r = requests.get(
                 self.ambari_http_protocol + "://" + self.ambari_server_host + ":" + self.ambari_server_port + "/api/v1/clusters",
-                auth=HTTPBasicAuth(self.ambari_user, self.ambari_pass))
+                auth=HTTPBasicAuth(self.ambari_user, self.ambari_pass),verify=False)
 
         except requests.exceptions.RequestException as e:
             log.debug(

--- a/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdp_metrics_extractor.py
+++ b/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/hdp_metrics_extractor.py
@@ -183,7 +183,7 @@ class MetricsExtractor:
 
     def get_cluster_name(self):
         try:
-            r = requests.get(self.ambari_http_protocol+"://"+self.ambari_server_host+":"+self.ambari_server_port+"/api/v1/clusters",auth = HTTPBasicAuth(self.ambari_user, self.ambari_pass))
+            r = requests.get(self.ambari_http_protocol+"://"+self.ambari_server_host+":"+self.ambari_server_port+"/api/v1/clusters",auth = HTTPBasicAuth(self.ambari_user, self.ambari_pass),verify=False)
         except requests.exceptions.RequestException as e:
             log.debug(
                 "Issue connecting to ambari server. Please check the process is up and running and responding as expected.")

--- a/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/mr_workload_extractor.py
+++ b/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/mr_workload_extractor.py
@@ -188,7 +188,7 @@ class MapreduceExtractor:
 
     def get_cluster_name(self):
         try:
-            r = requests.get(self.ambari_http_protocol+"://"+self.ambari_server_host+":"+self.ambari_server_port+"/api/v1/clusters",auth = HTTPBasicAuth(self.ambari_user, self.ambari_pass))
+            r = requests.get(self.ambari_http_protocol+"://"+self.ambari_server_host+":"+self.ambari_server_port+"/api/v1/clusters",auth = HTTPBasicAuth(self.ambari_user, self.ambari_pass),verify=False)
         except requests.exceptions.RequestException as e:
             log.debug(
                 "Issue connecting to ambari server. Please check the process is up and running and responding as expected.")

--- a/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/mr_workload_extractor.py
+++ b/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/mr_workload_extractor.py
@@ -131,21 +131,13 @@ class MapreduceExtractor:
         config_types = current_config_api_response['items'][0]['configurations']
         for config_type in config_types:
             if config_type['type'] == 'hdfs-site':
+                hdfs_config['ns'] = config_type['properties']['dfs.nameservices'].split(",")[0]
+                hdfs_config['nn1'] = config_type['properties']['dfs.ha.namenodes.' + hdfs_config['ns']].split(",")[0]
                 if config_type['properties']['dfs.http.policy'] == "HTTP_ONLY":
                     hdfs_config['http_type'] = 'http'
                 else:
                     hdfs_config['http_type'] = 'https'
-                try:
-                    hdfs_config['nameservices'] = config_type['properties']['dfs.nameservices']
-                    hdfs_config['namenodes.mycluster'] = config_type['properties']['dfs.ha.namenodes.mycluster']
-                    hdfs_config['port'] = config_type['properties'][
-                        'dfs.namenode.' + hdfs_config['http_type'] + '-address.' + hdfs_config['nameservices'] + '.' +
-                        hdfs_config['namenodes.mycluster'].split(",")[0]].split(":")[-1]
-                except:
-                    log.debug("HA is not enabled on this cluster")
-                    hdfs_config['port'] = \
-                        config_type['properties']['dfs.namenode.' + hdfs_config['http_type'] + '-address'].split(":")[
-                            -1]
+                hdfs_config['port'] = config_type['properties']['dfs.namenode.' + hdfs_config['http_type'] + '-address' + '.' + hdfs_config['ns'] + '.' + hdfs_config['nn1']].split(":")[-1]
                 hdfs_config['web_hdfs_enabled'] = config_type['properties']['dfs.webhdfs.enabled']
         return hdfs_config
 

--- a/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/ranger_policy_extractor.py
+++ b/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/ranger_policy_extractor.py
@@ -49,7 +49,7 @@ class RangerPolicyExtractor:
         try:
             r = requests.get(
                 self.ranger_ui_protocol + "://" + self.ranger_ui_server_name + ":" + self.ranger_ui_port + "/service/public/v2/api/policy",
-                auth=HTTPBasicAuth(self.ranger_admin_user, self.ranger_admin_pass))
+                auth=HTTPBasicAuth(self.ranger_admin_user, self.ranger_admin_pass),verify=False)
         except requests.exceptions.RequestException as e:
             log.error(
                 "Issue connecting to Ranger Admin UI. Please check the configs provided. Also, the process is up and running and responding as expected.")

--- a/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/spark_workload_extractor.py
+++ b/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/spark_workload_extractor.py
@@ -133,21 +133,13 @@ class SparkHistoryExtractor:
         config_types = current_config_api_response['items'][0]['configurations']
         for config_type in config_types:
             if config_type['type'] == 'hdfs-site':
+                hdfs_config['ns'] = config_type['properties']['dfs.nameservices'].split(",")[0]
+                hdfs_config['nn1'] = config_type['properties']['dfs.ha.namenodes.' + hdfs_config['ns']].split(",")[0]
                 if config_type['properties']['dfs.http.policy'] == "HTTP_ONLY":
                     hdfs_config['http_type'] = 'http'
                 else:
                     hdfs_config['http_type'] = 'https'
-                try:
-                    hdfs_config['nameservices'] = config_type['properties']['dfs.nameservices']
-                    hdfs_config['namenodes.mycluster'] = config_type['properties']['dfs.ha.namenodes.mycluster']
-                    hdfs_config['port'] = config_type['properties'][
-                        'dfs.namenode.' + hdfs_config['http_type'] + '-address.' + hdfs_config['nameservices'] + '.' +
-                        hdfs_config['namenodes.mycluster'].split(",")[0]].split(":")[-1]
-                except:
-                    log.debug("HA is not enabled on this cluster")
-                    hdfs_config['port'] = \
-                        config_type['properties']['dfs.namenode.' + hdfs_config['http_type'] + '-address'].split(":")[
-                            -1]
+                hdfs_config['port'] = config_type['properties']['dfs.namenode.' + hdfs_config['http_type'] + '-address' + '.' + hdfs_config['ns'] + '.' + hdfs_config['nn1']].split(":")[-1]
                 hdfs_config['web_hdfs_enabled'] = config_type['properties']['dfs.webhdfs.enabled']
         return hdfs_config
 

--- a/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/spark_workload_extractor.py
+++ b/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/spark_workload_extractor.py
@@ -192,7 +192,7 @@ class SparkHistoryExtractor:
         try:
             r = requests.get(
                 self.ambari_http_protocol + "://" + self.ambari_server_host + ":" + self.ambari_server_port + "/api/v1/clusters",
-                auth=HTTPBasicAuth(self.ambari_user, self.ambari_pass))
+                auth=HTTPBasicAuth(self.ambari_user, self.ambari_pass),verify=False)
         except requests.exceptions.RequestException as e:
             log.debug(
                 "Issue connecting to ambari server. Please check the process is up and running and responding as expected")

--- a/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/tez_workload_extractor.py
+++ b/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/tez_workload_extractor.py
@@ -202,7 +202,7 @@ class TezHistoryExtractor:
         try:
             r = requests.get(
                 self.ambari_http_protocol + "://" + self.ambari_server_host + ":" + self.ambari_server_port + "/api/v1/clusters",
-                auth=HTTPBasicAuth(self.ambari_user, self.ambari_pass))
+                auth=HTTPBasicAuth(self.ambari_user, self.ambari_pass),verify=False)
         except requests.exceptions.RequestException as e:
             log.debug(
                 "Issue connecting to ambari server. Please check the process is up and running and responding as expected")

--- a/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/tez_workload_extractor.py
+++ b/upgrade-toolkit/HDP-Discovery-Tool/mac-discovery-bundle-builder/tez_workload_extractor.py
@@ -143,21 +143,13 @@ class TezHistoryExtractor:
         config_types = current_config_api_response['items'][0]['configurations']
         for config_type in config_types:
             if config_type['type'] == 'hdfs-site':
+                hdfs_config['ns'] = config_type['properties']['dfs.nameservices'].split(",")[0]
+                hdfs_config['nn1'] = config_type['properties']['dfs.ha.namenodes.' + hdfs_config['ns']].split(",")[0]
                 if config_type['properties']['dfs.http.policy'] == "HTTP_ONLY":
                     hdfs_config['http_type'] = 'http'
                 else:
                     hdfs_config['http_type'] = 'https'
-                try:
-                    hdfs_config['nameservices'] = config_type['properties']['dfs.nameservices']
-                    hdfs_config['namenodes.mycluster'] = config_type['properties']['dfs.ha.namenodes.mycluster']
-                    hdfs_config['port'] = config_type['properties'][
-                        'dfs.namenode.' + hdfs_config['http_type'] + '-address.' + hdfs_config['nameservices'] + '.' +
-                        hdfs_config['namenodes.mycluster'].split(",")[0]].split(":")[-1]
-                except:
-                    log.debug("HA is not enabled on this cluster")
-                    hdfs_config['port'] = \
-                        config_type['properties']['dfs.namenode.' + hdfs_config['http_type'] + '-address'].split(":")[
-                            -1]
+                hdfs_config['port'] = config_type['properties']['dfs.namenode.' + hdfs_config['http_type'] + '-address' + '.' + hdfs_config['ns'] + '.' + hdfs_config['nn1']].split(":")[-1]
                 hdfs_config['web_hdfs_enabled'] = config_type['properties']['dfs.webhdfs.enabled']
         return hdfs_config
 


### PR DESCRIPTION
Two bugs are fixed in HDP for the discovery tool

1. Add verify=False for HTTPS request: When HTTPS is enabled, the code enforces to verify, which could be skipped. It could be a warning, but not a block error.
2. Modify the json parse for namespaces: Fix the JSON parse error

Please confirm.